### PR TITLE
Datetimepickerの実装

### DIFF
--- a/app/assets/stylesheets/reservations/_index.scss
+++ b/app/assets/stylesheets/reservations/_index.scss
@@ -17,6 +17,10 @@
     .count {
       width: 50px;
     }
+    #menu_id {
+      width: 100px;
+      height: 40px;
+    }
   }
   .form-btn {
     text-align: center;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
     <%= stylesheet_link_tag    'application', media: 'all' %>
     <%= javascript_include_tag 'application' %>
+    <link rel="stylesheet" href="http://ajax.googleapis.com/ajax/libs/jqueryui/1/themes/ui-lightness/jquery-ui.css">
   </head>
 
   <body>
@@ -33,5 +34,7 @@
     <%= yield %>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jquery-datetimepicker@2.5.20/build/jquery.datetimepicker.full.min.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jquery-datetimepicker@2.5.20/jquery.datetimepicker.css">
   </body>
 </html>

--- a/app/views/reservations/_datetime.html.erb
+++ b/app/views/reservations/_datetime.html.erb
@@ -1,0 +1,20 @@
+<div class="input-group date">
+  <input type="text" id="DateTime" autocomplete="off">
+</div>
+
+<script type="text/javascript">
+<!--
+$(function () {
+  $.datetimepicker.setLocale('ja');
+  $("#DateTime").attr("readonly", true);
+  $("#DateTime").datetimepicker({
+    allowTimes:[
+      '17:30', '18:00', '18:30', '19:00', '19:30', 
+      '20:00', '20:30', '21:00', '21:30'
+    ],
+    minDate:'-1970/01/01',
+    maxDate:'+1970/01/15',
+  });
+});
+-->
+</script>

--- a/app/views/reservations/index.html.erb
+++ b/app/views/reservations/index.html.erb
@@ -10,6 +10,10 @@
         <label for="exampleFormControlSelect1">コース名</label><br>
         <%= form.select :menu_id, [['Aコース', 1], ['Bコース', 2], ['Cコース', 3]], { include_blank: true, selected: 1 }, { id: "menu_id", class: "menu_id" } %>
       </div>
+      <div class="form-group">
+        <label for="exampleFormControlSelect1">日時</label><br>
+        <%= render partial: "datetime.html.erb" %>
+      </div>
       <div class="form-group count">
         <label for="exampleFormControlSelect1">人数を入力してください</label><br>
         <%= form.text_field :count, class: "count" %>


### PR DESCRIPTION
# What
datetimepickerの実装を行った
- ビュー画面の作成
- キー入力を不可にし、選択でしか選べないようにした
- 30分ごとの決められた時間でのみ選択できるようにした
- 現時点での日付から2週間までしか選べないようにした
- 日付を選択すると現在時刻が自動的に入力されてしまい、改善できなかった
- 今日の日付であれば過ぎた時間でも入力できてしまう

# Why
- 日時の入力の際にカレンダーから日付と時刻を選んだ方がスムーズなため
- 入力間違いを減らすことができるため