### PR TITLE
予約状況に基づいた予約可否表示の実装

### DIFF
--- a/app/assets/javascripts/reservations.js
+++ b/app/assets/javascripts/reservations.js
@@ -7,5 +7,33 @@ $(function () {
     ],
     minDate:'-1970/01/01',
     maxDate:'+1970/01/15',
+    defaultTime: '17:30'
   });
+
+  $("#people_number").on("keyup", function(){
+    let input = $(this).val();
+    let date = $("#DateTime").val();
+    $.ajax({
+      type: "GET",
+      url: "/reservations/search",
+      dataType: "json",
+      data: { count: input, date: date }
+    })
+    .done(function(reservations){
+      $("#over-people").empty();
+      if (reservations.length !== 0) {
+        let counts = 0;
+        reservations.forEach(function(reservation) {
+          counts += reservation.count;
+        });
+        if (parseInt(counts)+parseInt(input) > 16) {
+          let html = `<p>予約状況によりご希望の時間帯、人数での予約ができません</p>`
+          $("#over-people").append(html);
+        }
+      }
+    })
+    .fail(function(){
+      alert("通信に失敗しました");
+    })
+  })
 });

--- a/app/assets/javascripts/reservations.js
+++ b/app/assets/javascripts/reservations.js
@@ -1,4 +1,5 @@
 $(function () {
+  // datetimepickerの実装
   $.datetimepicker.setLocale('ja');
   $("#DateTime").datetimepicker({
     allowTimes:[
@@ -10,8 +11,9 @@ $(function () {
     defaultTime: '17:30'
   });
 
-  $("#people_number").on("keyup", function(){
-    let input = $(this).val();
+  // インクリメンタルサーチによる予約状況に基づいた予約の可否
+  function searchReservation(){
+    let input = $("#people_number").val();
     let date = $("#DateTime").val();
     $.ajax({
       type: "GET",
@@ -20,7 +22,7 @@ $(function () {
       data: { count: input, date: date }
     })
     .done(function(reservations){
-      $("#over-people").empty();
+      $(".over-people").empty();
       if (reservations.length !== 0) {
         let counts = 0;
         reservations.forEach(function(reservation) {
@@ -28,12 +30,21 @@ $(function () {
         });
         if (parseInt(counts)+parseInt(input) > 16) {
           let html = `<p>予約状況によりご希望の時間帯、人数での予約ができません</p>`
-          $("#over-people").append(html);
+          $(".over-people").append(html);
         }
       }
     })
     .fail(function(){
       alert("通信に失敗しました");
     })
-  })
+  };
+
+  $("#people_number").on("keyup", function(){
+    searchReservation();
+  });
+
+  $("#DateTime").change(function(){
+    searchReservation();
+  });
 });
+  

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,3 +3,5 @@
 @import "reservations/new";
 @import "reservations/complete";
 @import "restaurants/show";
+@import "config/colors";
+@import "modules/flash";

--- a/app/assets/stylesheets/config/colors.scss
+++ b/app/assets/stylesheets/config/colors.scss
@@ -1,0 +1,7 @@
+$white: #fff;
+$side_blue_dark: #253141;
+$side_blue_light: #2f3e51;
+$light_blue: #38AEF0;
+$light_gray: #999;
+$black: #434a54;
+$alert_orange: #F35500;

--- a/app/assets/stylesheets/modules/flash.scss
+++ b/app/assets/stylesheets/modules/flash.scss
@@ -1,0 +1,22 @@
+.notification {
+  position: relative;
+  .notice {
+    background-color: $light_blue;
+    color: $white;
+    text-align: center;
+  }
+
+  .alert {
+    position: absolute;
+    top: 100px;
+    width: 100%;
+    height: 50px;
+    padding: 0;
+    background-color: $alert_orange;
+    color: $white;
+    text-align: center;
+    line-height: 50px;
+    font-size: 20px;
+    margin-bottom: 0;
+  }
+}

--- a/app/assets/stylesheets/reservations/_index.scss
+++ b/app/assets/stylesheets/reservations/_index.scss
@@ -2,7 +2,8 @@
   padding: 100px 0;
   width: 100%;
   h2 {
-    margin: 50px 0;
+    margin-top: 80px;
+    margin-bottom: 50px;
     text-align: center;
   }
   label {
@@ -20,6 +21,9 @@
     #menu_id {
       width: 100px;
       height: 40px;
+    }
+    #over-people {
+      color: red;
     }
   }
   .form-btn {

--- a/app/assets/stylesheets/reservations/_index.scss
+++ b/app/assets/stylesheets/reservations/_index.scss
@@ -22,7 +22,7 @@
       width: 100px;
       height: 40px;
     }
-    #over-people {
+    .over-people {
       color: red;
     }
   }

--- a/app/views/layouts/_notifications.html.erb
+++ b/app/views/layouts/_notifications.html.erb
@@ -1,0 +1,7 @@
+<div class="notification">
+  <% flash.each do |message_type, message| %>
+      <div class="alert alert-<%= message_type %>">
+        <%= message %>
+      </div>
+  <% end %>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,7 +30,7 @@
         </script>
       </div>
     </header>
-
+    <%= render partial: "layouts/notifications.html.erb" %>
     <%= yield %>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>

--- a/app/views/reservations/index.html.erb
+++ b/app/views/reservations/index.html.erb
@@ -4,23 +4,25 @@
       <h2>予約情報を入力してください</h2>
       <div class="form-group ">
         <label for="exampleFormControlInput1">名前</label><br>
-        <%= form.text_field :user_name, class: "user_name", required: true %>
+        <%= form.text_field :user_name, class: "user_name", value: @reservation.try(:user_name), required: true %>
       </div>
       <div class="form-group">
         <label for="exampleFormControlSelect1">日時</label><br>
-        <%= form.text_field :reservation_date, type: "datetime", class: "reservation_date", id: "DateTime", autocomplete: "off", required: true %>
+        <%= form.text_field :reservation_date, type: "datetime", class: "reservation_date", id: "DateTime", value: @reservation.try(:reservation_date).try(:strftime, "%Y/%m/%d %H:%M"), autocomplete: "off", required: true %>
       </div>
       <div class="form-group">
         <label for="exampleFormControlSelect1">コース名</label><br>
-        <%= form.select :menu_id, [['席のみ', 1], ['Aコース', 2], ['Bコース', 3], ['Cコース', 4]], { include_blank: true, selected: 1 }, { id: "menu_id", class: "menu_id" } %>
+        <%= form.select :menu_id, [['席のみ', 1], ['Aコース', 2], ['Bコース', 3], ['Cコース', 4]], { include_blank: true, selected: @reservation.try(:menu_id) }, { id: "menu_id", class: "menu_id" } %>
       </div>
       <div class="form-group count">
         <label for="exampleFormControlSelect1">人数を入力してください</label><br>
-        <%= form.text_field :count, class: "count", type: "number", min: "1", max: "16", required: true %>
+        <%= form.text_field :count, class: "count", id: "people_number", autocomplete: "off", type: "number", min: "1", max: "16", required: true %>
+        <div id="over-people">
+        </div>
       </div>
       <div class="form-group">
         <label for="exampleFormControlTextarea1">ご要望</label><br>
-        <%= form.text_area :request, class: "request", size: "120x4" %>
+        <%= form.text_area :request, class: "request", size: "120x4", value: @reservation.try(:request) %>
       </div>
       <div class="form-btn">
         <%= form.submit "確認画面へ", class: "btn btn-primary" %>

--- a/app/views/reservations/index.html.erb
+++ b/app/views/reservations/index.html.erb
@@ -9,6 +9,8 @@
       <div class="form-group">
         <label for="exampleFormControlSelect1">日時</label><br>
         <%= form.text_field :reservation_date, type: "datetime", class: "reservation_date", id: "DateTime", value: @reservation.try(:reservation_date).try(:strftime, "%Y/%m/%d %H:%M"), autocomplete: "off", required: true %>
+        <div class="over-people">
+        </div>
       </div>
       <div class="form-group">
         <label for="exampleFormControlSelect1">コース名</label><br>
@@ -17,7 +19,7 @@
       <div class="form-group count">
         <label for="exampleFormControlSelect1">人数を入力してください</label><br>
         <%= form.text_field :count, class: "count", id: "people_number", autocomplete: "off", type: "number", min: "1", max: "16", required: true %>
-        <div id="over-people">
+        <div class="over-people">
         </div>
       </div>
       <div class="form-group">

--- a/app/views/reservations/search.json.jbuilder
+++ b/app/views/reservations/search.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @reservations do |reservation|
+  json.date reservation.reservation_date
+  json.count reservation.count
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,9 @@ Rails.application.routes.draw do
     member do
       get 'complete'
     end
+    collection do
+      get 'search'
+    end
   end
   resources :payments
 end


### PR DESCRIPTION
# What
- ユーザーが入力した予約情報を取得し、予約可能かどうかを処理する機能を実装した
1. 席時間を2時間の設定とし、ユーザーが入力した日時の前後1時間半のデータを全て取得できるようにした
1. 取得した予約データの人数の合計値を算出した
1. 既にある予約人数の合計値と、ユーザーが入力した人数の合計が16を超えるようなら予約ボタンを押した時にエラーメッセージと共に入力フォームを再度表示させるようにした。
- 上記機能をインクリメンタルサーチでも実装し、入力した日時と人数によって予約できない状況であれば、その旨を表示できるようにした
- インクリメンタルサーチによる表示は人数を変更したときと、日時を変更したときどちらでも対応できるようにした

# Why
- 何も設定しないとありえない状況でも予約できてしまうため
- 本来、人数の情報だけでなく席情報も紐づけて管理すべきだが、複雑になるため今回は簡易的な処理に留める
  (たとえば、20名収容可能だが席が10席の店で、予約者が全員1名ずつで10名いる場合、人数的には10名受け入れ可能だがその場合相席となってしまう)