### PR TITLE
reservations/new.html.erbのアップデート

### DIFF
--- a/app/views/reservations/new.html.erb
+++ b/app/views/reservations/new.html.erb
@@ -17,6 +17,12 @@
 </div>
 
 <div class="buttons">
+  <% if @reservation.menu_id == 1 %>
+    <%= render "only-sheets.html.erb" %>
+  <% else %>
+    <%= render "pay-form.html.erb" %>
+  <% end %>
+
   <%= form_tag reservations_path, method: :get, id:"payForm" do %>
     <%= hidden_field_tag 'user_name', @reservation.user_name %>
     <%= hidden_field_tag 'menu_id', @reservation.menu_id %>
@@ -26,11 +32,5 @@
     <div class="btn-pay">
       <button type="submit" class="btn btn-secondary">入力画面に戻る</button>
     </div>
-  <% end %>
-
-  <% if @reservation.menu_id == 1 %>
-    <%= render "only-sheets.html.erb" %>
-  <% else %>
-    <%= render "pay-form.html.erb" %>
   <% end %>
 </div>


### PR DESCRIPTION
# What
入力画面に戻るボタンとカード決済を行うボタンの順序を入れ替えた

# Why
元の順序だと、クレジットカード決済が終わった後にindexページに戻ってしまう
- paymentsコントローラーでbinding.pryしても止まらないため、そもそもcreateアクションが起こってない
- 席のみ予約の時は予約が完了する
- 入力画面に戻るボタンを削除すると正常に動いた
- 以上のことから、原因は不明だが入力ボタンがある状況だと、カード決済後、なぜか入力ボタンが押された挙動を示すと考えた
- ボタンの場所を入れ替えると解決した